### PR TITLE
feat/PGB-27-volunteer-home-page

### DIFF
--- a/src/pages/volunteer/Dashboard.tsx
+++ b/src/pages/volunteer/Dashboard.tsx
@@ -68,7 +68,23 @@ export default function Dashboard() {
             ) : error ? (
               <p className="text-[maroon] text-sm text-center">Error: {error}</p>
             ) : events.length === 0 ? (
-              <p className="text-gray-600 text-center">No events scheduled.</p>
+              <div className="w-full max-w-2xl mx-auto">
+                <div className="w-[350px] flex flex-col text-md text-black overflow-hidden font-semibold bg-[lightgray] border border-black rounded-lg text-left mx-auto shadow-md">
+                  <div className="w-full flex items-center gap-2 h-[40px] px-4 text-white font-bold bg-[maroon] border-b border-black rounded-t-lg">
+                    <span className="text-md">Upcoming Events</span>
+                  </div>
+
+                  <div className="flex flex-col last:border-none px-[10px] pt-[10px] pb-[20px]">
+                    <p className="flex items-start gap-3">
+                      <CalendarClock className="w-5 h-5 flex-shrink-0" />
+                      <span className="text-sm whitespace-pre-line">
+                        {`No events scheduled.\nCome back soon!`}
+                      </span>
+                    </p>
+                  </div>
+                </div>
+              </div>
+      
             ) : (
               <div className="w-full max-w-2xl mx-auto">
                 <div className="w-[350px] flex flex-col text-md text-black overflow-hidden font-semibold bg-white border border-black rounded-lg text-left mx-auto shadow-md">

--- a/src/pages/volunteer/Dashboard.tsx
+++ b/src/pages/volunteer/Dashboard.tsx
@@ -1,7 +1,113 @@
-export default function VolunteerDashboard() {
+import { useEffect, useState } from "react";
+import axios from "axios";
+import Header from "@components/Header";
+import Footer from "@components/Footer";
+import { useNavigate } from "react-router-dom";
+import { CalendarClock, ChevronRight } from "lucide-react";
+import { SignedIn, SignedOut, RedirectToSignIn } from "@clerk/clerk-react";
+
+interface Event {
+  event_id: string;
+  admin_id: string;
+  event_name: string;
+  date: string;
+  location: string;
+  description: string;
+}
+
+export default function Dashboard() {
+  const [events, setEvents] = useState<Event[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const API_URL = import.meta.env.VITE_API_URL;
+
+  useEffect(() => {
+    const fetchEvents = async () => {
+      try {
+        const response = await axios.get(`${API_URL}/events`, {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        });
+
+        console.log("Fetched events:", response.data);
+
+        if (!Array.isArray(response.data)) {
+          throw new Error("Expected array response from /events API");
+        }
+
+        setEvents(response.data);
+      } catch (err: any) {
+        console.error("Error fetching events:", err);
+        const message = err.response?.data?.detail || "Failed to fetch events";
+        setError(message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchEvents();
+  }, [API_URL]);
+
+  const navigate = useNavigate();
+
   return (
-    <div>Volunteer Dashboard</div>
-  )
+    <>
+      <SignedOut>
+        <RedirectToSignIn />
+      </SignedOut>
+  
+      <SignedIn>
+        <div className="min-h-screen w-full bg-white text-black flex flex-col">
+          <Header title="DASHBOARD" />
+  
+          <div className="w-full max-w-5xl mx-auto px-4 sm:px-10 pb-32 mt-4">
+            {loading ? (
+              <p className="text-gray-500 text-sm text-center">Loading...</p>
+            ) : error ? (
+              <p className="text-[maroon] text-sm text-center">Error: {error}</p>
+            ) : events.length === 0 ? (
+              <p className="text-gray-600 text-center">No events scheduled.</p>
+            ) : (
+              <div className="w-full max-w-2xl mx-auto">
+                <div className="w-[350px] flex flex-col text-md text-black overflow-hidden font-semibold bg-white border border-black rounded-lg text-left mx-auto shadow-md">
+                  <div className="w-full flex items-center gap-2 h-[40px] px-4 text-white font-bold bg-[maroon] border-b border-black rounded-t-lg">
+                    <span className="text-md">Upcoming Events</span>
+                  </div>
+  
+                  <div className="flex flex-col justify-center px-[10px] pt-[10px] pb-[20px] gap-4">
+                    {events.map((event) => (
+                      <div key={event.event_id} className="flex flex-col last:border-none pb-2">
+                        <p className="flex items-start gap-3">
+                          <CalendarClock className="w-5 h-5 flex-shrink-0" />
+                          <span className="text-sm break-words">{event.event_name}</span>
+                        </p>
+                        <p className="flex items-start gap-2 ml-8">
+                          <span className="text-xs break-words font-normal">{event.date}</span>
+                        </p>
+                        <div className="flex items-center justify-between ml-8">
+                          <span className="text-xs break-words font-normal">{event.location}</span>
+                          <button 
+                            onClick={() => navigate('/volunteer/events')}
+                            className="text-black"
+                          >
+                            <ChevronRight className="w-5 h-5" />
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+  
+          <Footer />
+        </div>
+      </SignedIn>
+    </>
+  );  
 }
 
 


### PR DESCRIPTION
• Integrated GET /events API to fetch and display upcoming events dynamically for signed-in volunteers.

• Added API error and loading state handling with proper UI feedback.

• Implemented conditional rendering:

- Displays a fallback card with a message when no events are scheduled.
- Renders a styled list of upcoming events using a card-style layout.

• Used lucide-react icons (CalendarClock, ChevronRight) for visual cues.

• ChevronRight button navigates to /volunteer/events page for event availability setting.

• Wrapped event list in a custom-styled card component matching ShadCN design conventions.

• Ensured secure routing: only authenticated users can access the dashboard (via SignedIn/SignedOut from Clerk).

NOTE: Header and Footer are not final yet. Will implement the final Header and Footer once the files are available for implementation.

![Screenshot 2025-05-14 203752](https://github.com/user-attachments/assets/adc1c32e-1e64-452b-9874-ac92abb15700)
